### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -641,7 +641,8 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			maskedToken := tokenString[:4] + "..." + tokenString[len(tokenString)-4:]
+			log.Printf("AuthN: Received bearer token %s", maskedToken)
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {


### PR DESCRIPTION
Fixes [https://github.com/GitHub-Insight-US-Lab/ghas/security/code-scanning/2](https://github.com/GitHub-Insight-US-Lab/ghas/security/code-scanning/2)

To fix the problem, we should avoid logging the bearer token in clear text. Instead, we can log a masked version of the token or omit it entirely from the logs. This way, we can still have useful logging information without exposing sensitive data.

The best way to fix this issue without changing existing functionality is to replace the logging of the full token with a masked version. We can log only the first few characters of the token to help with debugging while keeping the rest of the token secure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
