### PR TITLE
Fix code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r , err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes [https://github.com/GitHub-Insight-US-Lab/ghas/security/code-scanning/4](https://github.com/GitHub-Insight-US-Lab/ghas/security/code-scanning/4)

To fix the problem, we should use prepared statements with placeholder parameters instead of directly embedding user-provided data into the SQL query. This approach ensures that the database driver handles the user input safely, preventing SQL injection attacks.

1. Replace the `fmt.Sprintf` call with a SQL query string that uses placeholders (`?`) for the user-provided values.
2. Pass the user-provided values as arguments to the `stmt.Exec` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
