### PR TITLE
Fix code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -641,7 +641,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token")
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -653,14 +653,14 @@ func authnMiddleware(next http.Handler) http.Handler {
 			})
 
 			if err != nil {
-				log.Printf("AuthN: Invalid token %s", err)
+				log.Printf("AuthN: Invalid token")
 				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			} 
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token")
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)
@@ -671,12 +671,12 @@ func authnMiddleware(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			} else {
-				log.Printf("AuthN: Received token with invalid claims")
+				log.Printf("AuthN: Token has invalid claims")
 				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			}
 		}
-		log.Printf("AuthN: Received invalid authorization value")
+		log.Printf("AuthN: Invalid authorization value")
 		http.Error(w, "Forbidden", http.StatusForbidden)
 
 	})


### PR DESCRIPTION
Fixes [https://github.com/GitHub-Insight-US-Lab/ghas/security/code-scanning/3](https://github.com/GitHub-Insight-US-Lab/ghas/security/code-scanning/3)

To fix the problem, we should avoid logging the sensitive `authz` (Authorization) header directly. Instead, we can log a sanitized or obfuscated version of the token, or avoid logging it altogether. This ensures that sensitive information is not exposed in the logs.

- We will modify the logging statements to either remove the sensitive data or replace it with a placeholder.
- Specifically, we will change the logging on line 663 to avoid logging the `authz` variable directly.
- We will also review other logging statements to ensure no sensitive information is logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
